### PR TITLE
update to cdt 1.6, holds one minute of data instead of last n points

### DIFF
--- a/scripts/updater.js
+++ b/scripts/updater.js
@@ -2,7 +2,12 @@ const Eos = require('eosjs');
 const dotenv = require('dotenv');
 const axios = require('axios');
 
-const url = "https://min-api.cryptocompare.com/data/price?fsym=EOS&tsyms=USD&e=Kraken";
+const url = "https://min-api.cryptocompare.com/data/price?fsym=EOS&tsyms=USD&e=coinbase";
+//https://api.newdex.io/v1/price?symbol=everipediaiq-iq-eos
+//https://api.newdex.io/v1/price?symbol=thepeostoken-peos-eos
+//https://api.newdex.io/v1/price?symbol=betdicetoken-dice-eos
+//https://api.newdex.io/v1/price?symbol=eosiotptoken-tpt-eos
+//https://min-api.cryptocompare.com/data/price?fsym=EOS&tsyms=USD&e=Kraken
 
 dotenv.load();
 
@@ -34,8 +39,7 @@ function write(){
 					.then((contract) => {
 						contract.write({
 								owner: owner,
-								value: parseInt(Math.round(results.data.USD * 10000)),
-								symbol: "eosusd"
+								quotes:[{value: parseInt(Math.round((results.data.USD+.5) * 1000000)), pair: "eosusd"}]
 							},
 							{
 								scope: oracleContract,


### PR DESCRIPTION
1. updated to cdt 1.6 (note: in order to compile this pull request you must rename the file to DelphiOracle.cpp or change the class name to oracle)
2. when data is fed by any given BP, it trims any data points older than one-minute, instead of trimming to n number of data points.
3. scale in the updater.js is changed from 10000 to 1000000 because for example IQ is 0.000727 EOS per IQ
4. TODO, add two extended assets to the pair table.....updater.js should pass two extended assets (base and quote) along with the simple name (i.e. eosusd), and the write action should verify that those assets match the pair table corresponding to that simple name.
5. TODO, confgure action should take arguments to add a pair, currently it is hard coded.