### PR TITLE
Support WAX (and potentially other chains) with different system pair…

### DIFF
--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -23,9 +23,20 @@
 
 using namespace eosio;
 
-static const std::string system_str("system");
+// Setup per-chain system constants
+#ifdef WAX
+    const std::string SYSTEM_SYMBOL = "WAX";
+    const uint64_t SYSTEM_PRECISION = 8;
+    const name SYSTEM_PAIR_NAME = "waxusd"_n;
+    static const asset one_larimer = asset(1000000, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
+#else
+    const std::string SYSTEM_SYMBOL = "EOS";
+    const uint64_t SYSTEM_PRECISION = 4;
+    const name SYSTEM_PAIR_NAME = "eosusd"_n;
+    static const asset one_larimer = asset(1, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
+#endif
 
-static const asset one_larimer = asset(1, symbol("EOS", 4));
+static const std::string system_str("system");
 
 const checksum256 NULL_HASH;
 const eosio::time_point NULL_TIME_POINT = eosio::time_point(eosio::microseconds(0));
@@ -139,7 +150,7 @@ CONTRACT delphioracle : public eosio::contract {
     //variables
     uint64_t id;
     uint64_t total_datapoints_count;
-    asset total_claimed = asset(0, symbol("EOS", 4));
+    asset total_claimed = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
 
     //constants
     uint64_t datapoints_per_instrument = 21;
@@ -290,7 +301,7 @@ CONTRACT delphioracle : public eosio::contract {
     name proposer;
     name name;
 
-    asset bounty_amount = asset(0, symbol("EOS", 4));
+    asset bounty_amount = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
 
     std::vector<eosio::name> approving_custodians;
     std::vector<eosio::name> approving_oracles;
@@ -600,7 +611,7 @@ private:
         s.owner = owner;
         s.timestamp = current_time_point();
         s.count = 1;
-        s.balance = asset(0, symbol("EOS", 4));
+        s.balance = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
         s.last_claim = NULL_TIME_POINT;
       });
 
@@ -622,7 +633,7 @@ private:
         s.owner = owner;
         s.timestamp = current_time_point();
         s.count = 1;
-        s.balance = asset(0, symbol("EOS", 4));
+        s.balance = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
         s.last_claim = NULL_TIME_POINT;
       });
 
@@ -866,10 +877,10 @@ private:
 
       //avoid rounding issues by giving leftovers to top contributor
       if (i == 1){
-        payout = asset(amount, symbol("EOS", 4));
+        payout = asset(amount, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
       }
       else {
-        payout = asset(uquota, symbol("EOS", 4));
+        payout = asset(uquota, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
       }
 
       amount-= uquota;

--- a/include/delphioracle/delphioracle.hpp
+++ b/include/delphioracle/delphioracle.hpp
@@ -27,12 +27,10 @@ using namespace eosio;
 #ifdef WAX
     const std::string SYSTEM_SYMBOL = "WAX";
     const uint64_t SYSTEM_PRECISION = 8;
-    const name SYSTEM_PAIR_NAME = "waxusd"_n;
     static const asset one_larimer = asset(1000000, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
 #else
     const std::string SYSTEM_SYMBOL = "EOS";
     const uint64_t SYSTEM_PRECISION = 4;
-    const name SYSTEM_PAIR_NAME = "eosusd"_n;
     static const asset one_larimer = asset(1, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
 #endif
 

--- a/src/delphioracle.cpp
+++ b/src/delphioracle.cpp
@@ -228,25 +228,26 @@ ACTION delphioracle::configure(globalinput g) {
 
   }
 
-  if (pitr == pairs.end()){
+  // Add default pair if not on WAX
+  if (pitr == pairs.end() && SYSTEM_SYMBOL != "WAX"){
 
       pairs.emplace(_self, [&](auto& o) {
         o.active = true;
         o.bounty_awarded = true;
         o.bounty_edited_by_custodians = true;
         o.proposer = _self;
-        o.name = SYSTEM_PAIR_NAME;
-        o.bounty_amount = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
-        o.base_symbol =  symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION);
+        o.name = "eosusd"_n;
+        o.bounty_amount = asset(0, symbol("EOS", 4));
+        o.base_symbol =  symbol("EOS", 4);
         o.base_type = e_asset_type::eosio_token;
         o.base_contract = "eosio.token"_n;
         o.quote_symbol = symbol("USD", 2);
         o.quote_type = e_asset_type::fiat;
         o.quote_contract = ""_n;
-        o.quoted_precision = SYSTEM_PRECISION;
+        o.quoted_precision = 4;
       });
 
-      datapointstable dstore(_self, name(SYSTEM_PAIR_NAME).value);
+      datapointstable dstore(_self, name("eosusd"_n).value);
 
       //First data point starts at uint64 max
       uint64_t primary_key = 0;

--- a/src/delphioracle.cpp
+++ b/src/delphioracle.cpp
@@ -158,7 +158,7 @@ ACTION delphioracle::claim(name owner) {
   //   bt.erase( *existing );
   //} else {
   sstore.modify( *itr, _self, [&]( auto& a ) {
-      a.balance = asset(0, symbol("EOS", 4));
+      a.balance = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
       a.last_claim = current_time_point();
   });
 
@@ -195,7 +195,7 @@ ACTION delphioracle::configure(globalinput g) {
     gtable.emplace(_self, [&](auto& o) {
       o.id = 1;
       o.total_datapoints_count = 0;
-      o.total_claimed = asset(0, symbol("EOS", 4));
+      o.total_claimed = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
       o.datapoints_per_instrument = g.datapoints_per_instrument;
       o.bars_per_instrument = g.bars_per_instrument;
       o.vote_interval = g.vote_interval;
@@ -235,18 +235,18 @@ ACTION delphioracle::configure(globalinput g) {
         o.bounty_awarded = true;
         o.bounty_edited_by_custodians = true;
         o.proposer = _self;
-        o.name = "eosusd"_n;
-        o.bounty_amount = asset(0, symbol("EOS", 4));
-        o.base_symbol =  symbol("EOS", 4);
+        o.name = SYSTEM_PAIR_NAME;
+        o.bounty_amount = asset(0, symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION));
+        o.base_symbol =  symbol(SYSTEM_SYMBOL, SYSTEM_PRECISION);
         o.base_type = e_asset_type::eosio_token;
         o.base_contract = "eosio.token"_n;
         o.quote_symbol = symbol("USD", 2);
         o.quote_type = e_asset_type::fiat;
         o.quote_contract = ""_n;
-        o.quoted_precision = 4;
+        o.quoted_precision = SYSTEM_PRECISION;
       });
 
-      datapointstable dstore(_self, name("eosusd"_n).value);
+      datapointstable dstore(_self, name(SYSTEM_PAIR_NAME).value);
 
       //First data point starts at uint64 max
       uint64_t primary_key = 0;


### PR DESCRIPTION
Support WAX system token, precision, etc. with a compile time macro (-DWAX). This could be easily expanded to other chains. If there is a better way to do this I'm open to ideas.